### PR TITLE
1.0.1 beta DO NOT NECESSARILY HAVE TO MERGE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vineyard-blockchain",
-  "version": "1.0.0-beta.32",
+  "version": "1.0.0",
   "description": "A universal protocol for managing blockchains",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/schema.json
+++ b/src/schema.json
@@ -48,8 +48,8 @@
       "timeReceived": {
         "type": "datetime"
       },
-      "block": {
-        "type": "Block" 
+      "blockIndex": {
+        "type": "int"
       }
     }
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,7 +36,7 @@ export interface BaseTransaction {
     txid: string;
     amount: BigNumber;
     timeReceived: Date;
-    block: Identity<BlockInfo>;
+    blockIndex: number;
     status: TransactionStatus;
 }
 export interface SingleTransactionProperties {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface BaseTransaction {
   txid: string
   amount: BigNumber
   timeReceived: Date
-  block: Identity<BlockInfo>
+  blockIndex: number,
   status: TransactionStatus
 }
 


### PR DESCRIPTION
Changes types for salt-custodial-collateral. 
--SingleTransaction.block = uuid 
++SingleTransaction.blockIndex = int

Deposit monitor was sending the blockindex and not the block reference. SingleTransaction being external shouldn't know about UUIDs or databases